### PR TITLE
allow lucene limit 0

### DIFF
--- a/celements-search/src/main/java/com/celements/search/lucene/LuceneSearchResult.java
+++ b/celements-search/src/main/java/com/celements/search/lucene/LuceneSearchResult.java
@@ -36,7 +36,7 @@ public class LuceneSearchResult {
   private final boolean skipChecks;
 
   private int offset = 0;
-  private int limit = 0;
+  private int limit = -1;
 
   LuceneSearchResult(LuceneQuery query, List<String> sortFields, List<String> languages,
       boolean skipChecks) {
@@ -154,7 +154,7 @@ public class LuceneSearchResult {
   private List<SearchResult> getSearchResultList() throws LuceneSearchException {
     SearchResults results = luceneSearch();
     int offset = (getOffset() <= 0 ? 1 : getOffset() + 1);
-    int limit = (getLimit() <= 0 ? getSize() : getLimit());
+    int limit = (getLimit() < 0 ? getSize() : getLimit());
     return results.getResults(offset, limit);
   }
 

--- a/celements-search/src/test/java/com/celements/search/lucene/LuceneSearchResultTest.java
+++ b/celements-search/src/test/java/com/celements/search/lucene/LuceneSearchResultTest.java
@@ -66,7 +66,7 @@ public class LuceneSearchResultTest extends AbstractComponentTest {
   @Test
   public void test_getSetLimit() {
     LuceneSearchResult result = newResult(new LuceneQuery(), null, null, false);
-    assertEquals(0, result.getLimit());
+    assertEquals(-1, result.getLimit());
     result.searchResultsCache = createDefaultMock(SearchResults.class);
     result.setLimit(6);
     assertEquals(6, result.getLimit());


### PR DESCRIPTION
for only getting counts from the index `limit = 0` is reasonable.