### PR TITLE
CELDEV-1313 - Migrates mail dependencies from legacy javax.mail to Jakarta Mail

### DIFF
--- a/celements-mailsender/pom.xml
+++ b/celements-mailsender/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.celements</groupId>
@@ -26,6 +27,10 @@
     </repository>
   </repositories>
   <dependencies>
+    <dependency>
+      <groupId>com.sun.mail</groupId>
+      <artifactId>jakarta.mail</artifactId>
+    </dependency>
     <dependency>
       <groupId>jmock</groupId>
       <artifactId>jmock-cglib</artifactId>

--- a/celements-mailsender/src/main/java/com/xpn/xwiki/plugin/mailsender/MailSenderPlugin.java
+++ b/celements-mailsender/src/main/java/com/xpn/xwiki/plugin/mailsender/MailSenderPlugin.java
@@ -37,20 +37,20 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.activation.DataHandler;
-import javax.activation.DataSource;
-import javax.activation.FileDataSource;
-import javax.mail.BodyPart;
-import javax.mail.MessagingException;
-import javax.mail.Multipart;
-import javax.mail.SendFailedException;
-import javax.mail.Session;
-import javax.mail.Transport;
-import javax.mail.internet.AddressException;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeBodyPart;
-import javax.mail.internet.MimeMessage;
-import javax.mail.internet.MimeMultipart;
+import jakarta.activation.DataHandler;
+import jakarta.activation.DataSource;
+import jakarta.activation.FileDataSource;
+import jakarta.mail.BodyPart;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Multipart;
+import jakarta.mail.SendFailedException;
+import jakarta.mail.Session;
+import jakarta.mail.Transport;
+import jakarta.mail.internet.AddressException;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeBodyPart;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMultipart;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
@@ -323,15 +323,15 @@ public class MailSenderPlugin extends XWikiDefaultPlugin {
     message.setFrom(from);
 
     if (to != null) {
-      message.setRecipients(javax.mail.Message.RecipientType.TO, to);
+      message.setRecipients(jakarta.mail.Message.RecipientType.TO, to);
     }
 
     if (cc != null) {
-      message.setRecipients(javax.mail.Message.RecipientType.CC, cc);
+      message.setRecipients(jakarta.mail.Message.RecipientType.CC, cc);
     }
 
     if (bcc != null) {
-      message.setRecipients(javax.mail.Message.RecipientType.BCC, bcc);
+      message.setRecipients(jakarta.mail.Message.RecipientType.BCC, bcc);
     }
 
     message.setSubject(mail.getSubject(), EMAIL_ENCODING);


### PR DESCRIPTION
https://synjira.atlassian.net/browse/CELDEV-1313

**Migrates mail dependencies from legacy `javax.mail` to Jakarta Mail.**
- Adds managed `com.sun.mail:jakarta.mail:2.0.2` in `base-pom`
- Replaces `javax.mail:mail` in `celements-xwiki-core`
- Updates mail imports in core and mailsender to `jakarta.mail` / `jakarta.activation`
- Ensures generated bytecode calls `MimeBodyPart.setDataHandler(jakarta.activation.DataHandler)`, fixing the production `NoSuchMethodError`
- Verified `celements-xwiki-core` and `celements-mailsender` compile, and `celements-webapp` no longer resolves `mail-1.4.jar`